### PR TITLE
Don't worry about ambiguous blocks in RSpec

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,6 +5,10 @@ AllCops:
     - 'db/schema.rb'
     - 'node_modules/**/*.rb'
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Lint/EndAlignment:
   EnforcedStyleAlignWith: variable
 


### PR DESCRIPTION
Rubocop 0.48 introduced a new Lint/AmbiguousBlockAssocation cop [1], which
guards against the issues detailed in
https://github.com/bbatsov/rubocop/issues/3931.

However, the pattern is a solid RSpec idiom and not likely to cause the problems
Lint/AmbigiousBlockAssociation attempts to guard against. For example:

    expect { foo }.to change { bar }

so we'll just ignore it in RSpec as suggested in
https://github.com/bbatsov/rubocop/issues/4222.

[1]: https://github.com/bbatsov/rubocop/blob/d1b9d66c3518389b0c408a6a4a42061b36748df4/relnotes/v0.48.0.md