### PR TITLE
Enforce trailing commas

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -89,5 +89,11 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
 Style/WordArray:
   EnforcedStyle: brackets


### PR DESCRIPTION
This should provide for simpler diffs and arrays and hashes that are easier to
add to, and whose items are easier to move around internally.