### PR TITLE
Prefer descriptive name for errors

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -71,6 +71,9 @@ Metrics/MethodLength:
 Naming/FileName:
   Enabled: false
 
+Naming/RescuedExceptionsVariableName:
+  PreferredName: error
+
 Rails/DynamicFindBy:
   Enabled: false
 


### PR DESCRIPTION
Rubocop 0.67 seems to favor calling the exception variable `e`:

    app/exporters/leads_exporter.rb:94:29: C: Naming/RescuedExceptionsVariableName: Use e instead of error.
        rescue StandardError => error
                                ^^^^^

One-letter variables make Ole cry, we can't have that.