### PR TITLE
Make sure we load the git plugin for all those sweet aliases

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -5,7 +5,7 @@ export ZSH=$HOME/.oh-my-zsh
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # plugins=( bundler capistrano colorize git git-completion git-extras git-hubflow macports osx powder rails rake-fast rvm sublime zsh_reload)
-plugins=(aws gitfast git-prompt rvm sublime zsh_reload)
+plugins=(aws git gitfast git-prompt rvm sublime zsh_reload)
 
 # Load autojump with tab completions
 export FPATH="$FPATH:/opt/local/share/zsh/site-functions/"


### PR DESCRIPTION
https://github.com/robbyrussell/oh-my-zsh/wiki/Plugin:git

Not sure why this change is suddently needed, but after upgrading Oh My Zsh, my
`gst` etc stopped working.