### PR TITLE
Align arguments with fixed indentation

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
     - 'vendor/**/*'
   TargetRubyVersion: 2.6
 
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
Prefer

    foo :bar,
      :baz,
      :qux

    foo \
      :bar,
      :baz,
      :qux

over

    some_really_long_method_name :bar,
                                 :baz