### PR TITLE
Remove removed cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -76,9 +76,6 @@ Naming/FileName:
 Naming/RescuedExceptionsVariableName:
   PreferredName: error
 
-Rails/DynamicFindBy:
-  Enabled: false
-
 Style/BlockDelimiters:
   Enabled: false
 


### PR DESCRIPTION
Rails/DynamicFindBy is gone, so we don't have to disable it any longer.