### PR TITLE
Update obsolete cop names

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -13,22 +13,16 @@ AllCops:
     - 'vendor/**/*'
   TargetRubyVersion: 2.6
 
-Layout/AlignArguments:
-  EnforcedStyle: with_fixed_indentation
-
-Layout/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
-
 Layout/DotPosition:
   EnforcedStyle: trailing
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:
@@ -36,6 +30,9 @@ Layout/MultilineMethodCallIndentation:
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space


### PR DESCRIPTION
As of Rubocop 0.77 these are obsolete:

> Error: The `Layout/AlignParameters` cop has been renamed to `Layout/ParameterAlignment`.
> (obsolete configuration found in .rubocop.yml, please update it)
> The `Layout/IndentFirstArrayElement` cop has been renamed to `Layout/FirstArrayElementIndentation`.
> (obsolete configuration found in .rubocop.yml, please update it)
> The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
> (obsolete configuration found in .rubocop.yml, please update it)