### PR TITLE
Default new cops to enabled

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'lib/templates/**/*.rb'
     - 'node_modules/**/*'
     - 'vendor/**/*'
+  NewCops: enable
   TargetRubyVersion: 2.6
 
 Layout/DotPosition:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -17,9 +17,6 @@ AllCops:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 
@@ -44,24 +41,12 @@ Layout/MultilineOperationIndentation:
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
 
 Metrics/AbcSize:
   Exclude:
@@ -95,29 +80,14 @@ Style/BlockDelimiters:
 Style/Documentation:
   Enabled: false
 
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
 
 Style/IfUnlessModifier:
   Enabled: false
 
 Style/SafeNavigation:
   Enabled: false
-
-Style/SlicingWithRange:
-  Enabled: true
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
This prevents future messages like

> The following cops were added to RuboCop, but are not configured.
> Please set Enabled to either `true` or `false` in your `.rubocop.yml`
> file
> ...

and subsequent annoying configs with a ton of `Enabled: true` blocks.

This way we stay as close to Rubocop standard practices as possible
while still leaving us the option of _disabling_ a cop if it turns out
we prefer something else, instead of having to manually enable cops that
we don't know if we like.

For more information: https://docs.rubocop.org/rubocop/versioning.html