### PR TITLE
Make Rubocop sort like Ruby, VS Code and others

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.6
 
+Bundler/OrderedGems:
+  ConsiderPunctuation: true
+
 Layout/DotPosition:
   EnforcedStyle: trailing
 


### PR DESCRIPTION
Without this the following order is correct according to Rubocop:

1. "capistrano3-puma"
2. "capistrano-bundler"

However Ruby says something different:

    > ["capistrano3-puma", "capistrano-bundler"].sort
    => ["capistrano-bundler", "capistrano3-puma"]

and sorting using `sort(1)`, VS Code and Sublime Text gives us the same
ordering as Ruby:

1. "capistrano-bundler"
2. "capistrano3-puma"