### PR TITLE
Allow all UTF-8 characters in comments

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -77,6 +77,9 @@ Naming/FileName:
 Naming/RescuedExceptionsVariableName:
   PreferredName: error
 
+Style/AsciiComments:
+  Enabled: false
+
 Style/BlockDelimiters:
   Enabled: false
 


### PR DESCRIPTION
This seems like a perfectly valid comment to me:

    # Using Hpricot to convert HTML entities as CGI.unescapeHTML doesn't decode
    # all entities. Namely æ, ø, and å aren't converted.

Don't give us those US-centric judgements