### PR TITLE
Default to fast forward only pulls

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -52,6 +52,9 @@
 [mirror]
   summary = true
 
+[pull]
+  ff = only
+
 [push]
   default = simple
 


### PR DESCRIPTION
This works around a warning from git:

    warning: Pulling without specifying how to reconcile divergent branches is
    discouraged. You can squelch this message by running one of the following
    commands sometime before your next pull:

      git config pull.rebase false  # merge (the default strategy)
      git config pull.rebase true   # rebase
      git config pull.ff only       # fast-forward only

    You can replace "git config" with "git config --global" to set a default
    preference for all repositories. You can also pass --rebase, --no-rebase,
    or --ff-only on the command line to override the configured default per
    invocation.

This means git pull is going to fail if the incoming changes cannot be
replayed directly onto the current branch.

It prevents merge commits from pulling, but does require a little bit
branch and rebase magic to work around the cases where your local
repository has changes not in origin:

    git branch newbranch
    git fetch origin
    git reset --hard origin/main
    git checkout newbranch
    get rebase main
    git checkout main
    git merge newbranch
    git push