### PR TITLE
Remove deprecated zsh_reload plugin

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -5,7 +5,7 @@ export ZSH=$HOME/.oh-my-zsh
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # plugins=( bundler capistrano colorize git git-completion git-extras git-hubflow macports osx powder rails rake-fast rvm sublime zsh_reload)
-plugins=(aws git gitfast git-prompt rvm sublime zsh_reload)
+plugins=(aws git gitfast git-prompt rvm sublime)
 
 # Load autojump with tab completions
 export FPATH="$FPATH:/opt/local/share/zsh/site-functions/"


### PR DESCRIPTION
Oh My Zsh says:

> The `zsh_reload` plugin is deprecated and will be removed.
> Use `omz reload` or `exec zsh` instead.