### PR TITLE
Rubocop: Don't worry about offenses in generated migrations

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'config/initializers/simple_form_bootstrap.rb'
     - 'config/initializers/wrap_parameters.rb'
     - 'config/puma.rb'
+    - 'db/migrate/*.active_storage.rb'
     - 'db/schema.rb'
     - 'lib/templates/**/*.rb'
     - 'node_modules/**/*'


### PR DESCRIPTION
ActiveStorage maintains their own tables in the database by generating the occasional migration. For some reason they don't seem to adhere to our coding guidelines ;)

All of those generated migrations are affixed with .active_storage.rb, which means we can easily ignore them.