### PR TITLE
Disable named subject cop in Rubocop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -82,6 +82,9 @@ Naming/FileName:
 Naming/RescuedExceptionsVariableName:
   PreferredName: error
 
+RSpec/NamedSubject:
+  Enabled: false
+
 Style/AsciiComments:
   Enabled: false
 


### PR DESCRIPTION
If specs are properly written, we don't need a named subject as a subject is considered an instance of the described class, so disabling this cop could be considered a code improvement.