### PR TITLE
Prefer trailing commas that optimize for diffs

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -113,7 +113,7 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
+  EnforcedStyleForMultiline: diff_comma
 
 Style/WordArray:
   EnforcedStyle: brackets


### PR DESCRIPTION
Good

    {
      :foo => "Foo",
      :bar => "Bar",
    }

    {
      :foo => "Foo", :bar => "Bar",
    }

    {:foo => "Foo", :bar => "Bar"}

Bad

    {
      :foo => "Foo",
      :bar => "Bar"
    }

    {
      :foo => "Foo", :bar => "Bar"
    }