### PR TITLE
Don't lint any schema files

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - 'config/initializers/wrap_parameters.rb'
     - 'config/puma.rb'
     - 'db/migrate/*.active_storage.rb'
-    - 'db/schema.rb'
+    - 'db/*schema.rb'
     - 'lib/templates/**/*.rb'
     - 'node_modules/**/*'
     - 'vendor/**/*'


### PR DESCRIPTION
db/queue_schema.rb is generated by the queue system and is not meant to be edited by hand, so we shouldn't lint it, nor should we lint db/schema.rb or any other database schema files.