### PR TITLE
Don't include RSpec-cops in generic rubocop.yml

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -82,9 +82,6 @@ Naming/FileName:
 Naming/RescuedExceptionsVariableName:
   PreferredName: error
 
-RSpec/NamedSubject:
-  Enabled: false
-
 Style/AsciiComments:
   Enabled: false
 


### PR DESCRIPTION
RSpec/NamedSubject is only relevant for projects with rspec and will fail if rubocop-rspec isn't loaded:

> Error: unrecognized cop or department RSpec/NamedSubject found in
> .rubocop.yml

This rubocop configuration should be generic enough for all Ruby projects.